### PR TITLE
feat: add --stdio flag

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,8 @@
+/** Reads input from stdin */
+export async function readStdin() {
+  let data = ''
+  for await (const chunk of process.stdin) {
+    data += chunk;
+  }
+  return data;
+}


### PR DESCRIPTION
Closes https://github.com/JamieMason/ts-import-types-cli/issues/4

Adds two new flags:

- --stdio - read from stdin and write to stdout
- --file-path - file location to use for --stdio source code

example:

```
ts-import-types --stdio --file-path src/index.ts < src/index.ts > out.ts
```